### PR TITLE
Compatibility Fix for Homeward Journey

### DIFF
--- a/Content/Biomes/CrabCrevice/CrabCreviceGenerator.cs
+++ b/Content/Biomes/CrabCrevice/CrabCreviceGenerator.cs
@@ -680,6 +680,9 @@ namespace Aequus.Content.Biomes.CrabCrevice {
             else if (ThoriumMod.Instance != null) {
                 wantedDirection = Main.dungeonX * 2 < Main.maxTilesX ? -1 : 1;
             }
+            else if (ContinentOfJourney.Instance != null) {
+                wantedDirection = 1;
+            }
 
             if (Main.remixWorld) {
                 location.X = GenVars.UndergroundDesertLocation.X + GenVars.UndergroundDesertLocation.Width / 2;

--- a/CrossMod/ContinentOfJourney.cs
+++ b/CrossMod/ContinentOfJourney.cs
@@ -1,0 +1,20 @@
+﻿using Aequus.Common.CrossMod;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria.ModLoader;
+
+namespace Aequus.CrossMod {
+    internal class ContinentOfJourney : ModSupport<ContinentOfJourney> {
+        public override void SafeLoad(Mod mod) {
+        }
+
+        public override void AddRecipes() {
+        }
+
+        public override void SafeUnload() {
+        }
+    }
+}


### PR DESCRIPTION
Homeward Journey always modifies the left ocean. So I made it always generate the beach biome on the right if Homeward Journey is detected.